### PR TITLE
update readme's and add docs how it works

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -38,5 +38,5 @@ docs about benchmarking: https://bheisler.github.io/criterion.rs/book/criterion_
 
 ## References
 
-Older discussion on introducing markdown into deltachat: https://github.com/deltachat/interface/pull/20
-Feature request for message markdown in the forum: https://support.delta.chat/t/markdown-support-in-chat/159
+- Older discussion on introducing markdown into deltachat: https://github.com/deltachat/interface/pull/20
+- Feature request for message markdown in the forum: https://support.delta.chat/t/markdown-support-in-chat/159

--- a/README.MD
+++ b/README.MD
@@ -11,6 +11,8 @@ Have the same rich message parsing on all platforms.
 The basic idea is that core can use this library to convert messages to an AST format,
 that can then be displayed by the UIs how they see fit, for desktop it will be converted to react elements.
 
+> Desktop already uses this package (minus the markdown, because it does not make sense to only have markdown only on one platform) as wasm module (see `./message_parser_wasm`), later this will probably be integrated into deltachat core.
+
 ## Coding Principles
 
 - **many** test cases

--- a/docs.md
+++ b/docs.md
@@ -1,0 +1,34 @@
+### How parsing currently roughly works
+
+We use the nom parser, which basically consists of functions that check the input and when it matches they consume the part of the input that matched.
+
+So currently, the parsing works like this:
+
+pseudocode:
+
+```rs
+let mut remaining_input = input;
+let output = Vec<Element>
+
+while !remaining_input.is_empty() {
+    let res = {
+        // try the following parsers in this order (order is important with some parsers)
+        1. hashtag(input)
+        2. email_address(input)
+        3. link(input)
+        4. bot_command_suggestion(input)
+        5. linebreak(input)
+        last option: consumes all text until [parse_text_element] works again
+    }
+    remaining_input = res.remaining_input
+    output.push(res.element)
+}
+```
+
+### Contributing principles:
+
+The single most important thing for this crate is testing, as long as we cover as many cases in tests as we can the parser stays working.
+
+The second principle is speed, we can test that with benchmarks.
+
+The third priority is binary size, so be careful with huge extra libraries, maybe there is a better way.

--- a/message_parser_wasm/README.md
+++ b/message_parser_wasm/README.md
@@ -1,25 +1,74 @@
-## About
+# DeltaChat Message Parser WASM
 
-This is the message parser as wasm package, see example.js on details how to use it.
-The idea is to use this in `deltachat-desktop`, so it can be already tried out without adding it to `deltachat-core`.
+Parsing of Links, email addresses, simple text formatting (markdown subset), user mentions, hashtags and more in DeltaChat messages.
+
+The specification can be found in [spec.md](https://github.com/deltachat/message-parser/blob/master/message_parser_wasm/spec.md).
+
+## The Idea behind it
+
+Have the same rich message parsing on all platforms.
+
+The basic idea is that core can use this library to convert messages to an AST format,
+that can then be displayed by the UIs how they see fit, for desktop it will be converted to react elements.
+
+> Desktop already uses this package (minus the markdown, because it does not make sense to only have markdown on desktop and not also on iOS and android) as wasm module (see `./message_parser_wasm`), later this will probably be integrated into deltachat core.
+
+Read more about the project on github: https://github.com/deltachat/message-parser
 
 ## 🚴 Usage
 
-see [example.js](./example.js)
+```ts
+function parse_text(s: string, enable_markdown: boolean): ParsedElement[];
+```
 
-### 🛠️ Build with `wasm-pack build`
+```js
+import init, { parse_text } from "./pkg/message_parser_wasm.js";
+
+init().then(() => {
+    let parsed = parse_text("hello **world**", true)
+
+    let result = parsed.map(element => {
+        switch element.t {
+            case "Bold":
+                return `<b>${element.c}</b>`
+                break;
+            case "Text"
+                return element.c
+            // ...
+            default
+                console.error(`type ${element.t} not known/implemented yet`, element);
+                return JSON.stringify(element)
+        }
+    }).join("")
+
+    console.log(result) // "hello <b>world</b>"
+})
+```
+
+> DO **NOT** actually write html with user input like that, this is for demonstration purposes ONLY!
+> It let's you and your users open to **XSS attacks**, the examples bellow are much better suitable for reference or copy+pasting.
+
+also see [example.js](./example.js) and test it live on <https://deltachat.github.io/message-parser/>
+
+For usage in react you can look at how we integrated this package in deltachat-desktop: [deltachat-desktop/src/renderer/components/message/MessageMarkdown.tsx](https://github.com/deltachat/deltachat-desktop/blob/7493f898bc3dff06b20565a48e93564f5996b855/src/renderer/components/message/MessageMarkdown.tsx)
+
+If you want to see it in action in deltachat-desktop, feel free to download it on <https://get.delta.chat>.
+
+### For Devs
+
+#### 🛠️ Build with `wasm-pack build`
 
 ```
 wasm-pack build --scope deltachat --target web
 ```
 
-### 🔬 Test in Headless Browsers with `wasm-pack test`
+#### 🔬 Test in Headless Browsers with `wasm-pack test`
 
 ```
 wasm-pack test --headless --firefox
 ```
 
-### 🎁 Publish to NPM with `wasm-pack publish`
+#### 🎁 Publish to NPM with `wasm-pack publish`
 
 ```
 wasm-pack publish --target web

--- a/message_parser_wasm/README.md
+++ b/message_parser_wasm/README.md
@@ -4,6 +4,8 @@ Parsing of Links, email addresses, simple text formatting (markdown subset), use
 
 The specification can be found in [spec.md](https://github.com/deltachat/message-parser/blob/master/message_parser_wasm/spec.md).
 
+The parser is written in rust with the [nom crate](https://github.com/Geal/nom) and compiled to web assembly for this package.
+
 ## The Idea behind it
 
 Have the same rich message parsing on all platforms.


### PR DESCRIPTION
the readme inside of the wasm folder is shown on npm, the reason in changing it is that we could maybe get contributors over this, or other projects could use this parser if they want.


addresses some of #11

closes #10 for now, sure could be done even better, though now this is already better than nothing.