### PR TITLE
do not consume `,`,`.`,`;` or `:` at end of link closes #13

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -42,6 +42,8 @@ Make URLs clickable.
 
 - other links like `mailto:` (note there is just a single `:`, no `://`) will get separate parsing that includes a whitelisted protocol name, otherwise there will likely be unexpected behavior if user types `hello:world` - will be recognized as link.
 
+- `.`,`,`,`;`,`:` should not be parsed as an ending char of an inline-link(this rule is only for standalone/inline links)
+
 #### Allowed schemes:
 
 - all Common Internet Scheme links (containing `//` after scheme)

--- a/tests/text_to_ast/desktop_set.rs
+++ b/tests/text_to_ast/desktop_set.rs
@@ -162,9 +162,7 @@ fn email_address_standalone() {
 #[test]
 fn email_address_example() {
     assert_eq!(
-        parse_desktop_set(
-            "This is an email address: message.parser@example.com\nMessage me there"
-        ),
+        parse_desktop_set("This is an email address: message.parser@example.com\nMessage me there"),
         vec![
             Text("This is an email address: "),
             EmailAddress("message.parser@example.com"),

--- a/tests/text_to_ast/desktop_set.rs
+++ b/tests/text_to_ast/desktop_set.rs
@@ -293,3 +293,31 @@ fn labeled_link_example_should_not_work() {
         ]
     );
 }
+
+#[test]
+fn inline_link_do_not_eat_last_char_if_it_is_special() {
+    assert_eq!(
+        parse_desktop_set("https://delta.chat,"),
+        vec![
+            Link {
+                destination: link_destination_for_testing("https://delta.chat")
+            },
+            Text(",")
+        ]
+    );
+    assert_eq!(
+        parse_desktop_set("https://delta.chat."),
+        vec![
+            Link {
+                destination: link_destination_for_testing("https://delta.chat")
+            },
+            Text(".")
+        ]
+    );
+    assert_eq!(
+        parse_desktop_set("https://delta.chat/page.hi"),
+        vec![Link {
+            destination: link_destination_for_testing("https://delta.chat/page.hi")
+        }]
+    );
+}

--- a/tests/text_to_ast/markdown.rs
+++ b/tests/text_to_ast/markdown.rs
@@ -552,3 +552,51 @@ fn labeled_link_example() {
         ]
     );
 }
+
+#[test]
+fn labeled_link_can_have_comma_or_dot_at_end() {
+    assert_eq!(
+        parse_markdown_text("you can find the details [here](https://delta.chat/en/help.)."),
+        vec![
+            Text("you can find the details "),
+            LabeledLink {
+                label: vec![Text("here")],
+                destination: link_destination_for_testing("https://delta.chat/en/help.")
+            },
+            Text(".")
+        ]
+    );
+    assert_eq!(
+        parse_markdown_text("you can find the details [here](https://delta.chat/en/help,)."),
+        vec![
+            Text("you can find the details "),
+            LabeledLink {
+                label: vec![Text("here")],
+                destination: link_destination_for_testing("https://delta.chat/en/help,")
+            },
+            Text(".")
+        ]
+    );
+    assert_eq!(
+        parse_markdown_text("you can find the details [here](https://delta.chat/en/help:)."),
+        vec![
+            Text("you can find the details "),
+            LabeledLink {
+                label: vec![Text("here")],
+                destination: link_destination_for_testing("https://delta.chat/en/help:")
+            },
+            Text(".")
+        ]
+    );
+    assert_eq!(
+        parse_markdown_text("you can find the details [here](https://delta.chat/en/help;)."),
+        vec![
+            Text("you can find the details "),
+            LabeledLink {
+                label: vec![Text("here")],
+                destination: link_destination_for_testing("https://delta.chat/en/help;")
+            },
+            Text(".")
+        ]
+    );
+}

--- a/tests/text_to_ast/text_only.rs
+++ b/tests/text_to_ast/text_only.rs
@@ -289,3 +289,78 @@ fn labeled_link_example_should_not_work() {
         ]
     );
 }
+
+#[test]
+fn link_do_not_consume_last_comma() {
+    assert_eq!(
+        parse_only_text("you can find the details on https://delta.chat/en/help,"),
+        vec![
+            Text("you can find the details on "),
+            Link {
+                destination: link_destination_for_testing("https://delta.chat/en/help")
+            },
+            Text(",")
+        ]
+    );
+}
+
+#[test]
+fn link_do_not_consume_last_semicolon_or_colon() {
+    assert_eq!(
+        parse_only_text("you can find the details on https://delta.chat/en/help;"),
+        vec![
+            Text("you can find the details on "),
+            Link {
+                destination: link_destination_for_testing("https://delta.chat/en/help")
+            },
+            Text(";")
+        ]
+    );
+    assert_eq!(
+        parse_only_text("you can find the details on https://delta.chat/en/help:"),
+        vec![
+            Text("you can find the details on "),
+            Link {
+                destination: link_destination_for_testing("https://delta.chat/en/help")
+            },
+            Text(":")
+        ]
+    );
+}
+
+#[test]
+fn link_do_not_consume_last_dot() {
+    assert_eq!(
+        parse_only_text("you can find the details on https://delta.chat/en/help."),
+        vec![
+            Text("you can find the details on "),
+            Link {
+                destination: link_destination_for_testing("https://delta.chat/en/help")
+            },
+            Text(".")
+        ]
+    );
+    assert_eq!(
+        parse_only_text("you can find the details on https://delta.chat/en/help.txt."),
+        vec![
+            Text("you can find the details on "),
+            Link {
+                destination: link_destination_for_testing("https://delta.chat/en/help.txt")
+            },
+            Text(".")
+        ]
+    );
+}
+
+#[test]
+fn link_with_file_extention() {
+    assert_eq!(
+        parse_only_text("you can find the details on https://delta.chat/en/help.html"),
+        vec![
+            Text("you can find the details on "),
+            Link {
+                destination: link_destination_for_testing("https://delta.chat/en/help.html")
+            }
+        ]
+    );
+}


### PR DESCRIPTION
closes #13