### PR TITLE
fix link parenthesis issue

### DIFF
--- a/src/parser/link_url.rs
+++ b/src/parser/link_url.rs
@@ -187,7 +187,10 @@ fn is_safe(char: char) -> bool {
 }
 
 fn is_extra(char: char) -> bool {
-    matches!(char, '!' | '*' | '\'' | '(' | ')' | ',')
+    matches!(
+        char,
+        '!' | '*' | '\'' | '(' | ')' | ',' | '{' | '}' | '[' | ']' | '<' | '>'
+    )
 }
 
 fn is_unreserved(char: char) -> bool {

--- a/src/parser/parse_from_text/text_elements.rs
+++ b/src/parser/parse_from_text/text_elements.rs
@@ -3,6 +3,7 @@ use crate::parser::link_url::LinkDestination;
 
 use super::base_parsers::*;
 use super::Element;
+use crate::nom::{Offset, Slice};
 use nom::bytes::complete::take_while;
 use nom::{
     bytes::{
@@ -79,15 +80,35 @@ fn link_intern(input: &str) -> IResult<&str, (), CustomError<&str>> {
         match char {
             '(' => {
                 parentheses_count += 1;
+                // if there is no closing bracket in the link, then don't take the bracket as a part of the link
+                if (<&str>::clone(&consumed)).slice(i..).find(')').is_none() {
+                    alternative_offset = Some(i);
+                    break;
+                }
             }
             '{' => {
                 curly_brackets_count += 1;
+                // if there is no closing bracket in the link, then don't take the bracket as a part of the link
+                if (<&str>::clone(&consumed)).slice(i..).find('}').is_none() {
+                    alternative_offset = Some(i);
+                    break;
+                }
             }
             '[' => {
                 brackets_count += 1;
+                // if there is no closing bracket in the link, then don't take the bracket as a part of the link
+                if (<&str>::clone(&consumed)).slice(i..).find(']').is_none() {
+                    alternative_offset = Some(i);
+                    break;
+                }
             }
             '<' => {
                 angle_backets += 1;
+                // if there is no closing bracket in the link, then don't take the bracket as a part of the link
+                if (<&str>::clone(&consumed)).slice(i..).find('>').is_none() {
+                    alternative_offset = Some(i);
+                    break;
+                }
             }
             ')' => {
                 if parentheses_count == 0 {
@@ -126,7 +147,6 @@ fn link_intern(input: &str) -> IResult<&str, (), CustomError<&str>> {
     }
 
     if let Some(offset) = alternative_offset {
-        use crate::nom::Slice;
         let remaining = input.slice(offset..);
         Ok((remaining, ()))
     } else {
@@ -138,7 +158,6 @@ pub(crate) fn link(input: &str) -> IResult<&str, Element, CustomError<&str>> {
     // basically
     //let (input, content) = recognize(link_intern)(input)?;
     // but don't eat the last char if it is one of these: `.,;:`
-    use crate::nom::{Offset, Slice};
     let i = <&str>::clone(&input);
     let i2 = <&str>::clone(&input);
     let i3 = <&str>::clone(&input);

--- a/src/parser/parse_from_text/text_elements.rs
+++ b/src/parser/parse_from_text/text_elements.rs
@@ -73,7 +73,7 @@ fn link_intern(input: &str) -> IResult<&str, (), CustomError<&str>> {
     let mut parentheses_count = 0usize; // ()
     let mut curly_brackets_count = 0usize; // {}
     let mut brackets_count = 0usize; // []
-    let mut angle_backets = 0usize; // <>
+    let mut angle_brackets = 0usize; // <>
 
     let mut alternative_offset = None;
     for (i, char) in consumed.chars().enumerate() {
@@ -103,7 +103,7 @@ fn link_intern(input: &str) -> IResult<&str, (), CustomError<&str>> {
                 }
             }
             '<' => {
-                angle_backets += 1;
+                angle_brackets += 1;
                 // if there is no closing bracket in the link, then don't take the bracket as a part of the link
                 if (<&str>::clone(&consumed)).slice(i..).find('>').is_none() {
                     alternative_offset = Some(i);
@@ -135,11 +135,11 @@ fn link_intern(input: &str) -> IResult<&str, (), CustomError<&str>> {
                 }
             }
             '>' => {
-                if angle_backets == 0 {
+                if angle_brackets == 0 {
                     alternative_offset = Some(i);
                     break;
                 } else {
-                    angle_backets -= 1;
+                    angle_brackets -= 1;
                 }
             }
             _ => continue,

--- a/tests/text_to_ast/text_only.rs
+++ b/tests/text_to_ast/text_only.rs
@@ -364,3 +364,62 @@ fn link_with_file_extention() {
         ]
     );
 }
+
+
+
+#[test]
+fn parenthesis_in_links() {
+    assert_eq!(
+        parse_only_text("links can contain parenthesis, https://en.wikipedia.org/wiki/Bracket_(disambiguation) is an example of this."),
+        vec![
+            Text("links can contain parenthesis, "),
+            Link {
+                destination: link_destination_for_testing("https://en.wikipedia.org/wiki/Bracket_(disambiguation)")
+            },
+            Text(" is an example of this.")
+        ]
+    );
+}
+
+#[test]
+fn link_in_parenthesis() {
+    assert_eq!(
+        parse_only_text("for more information see (https://github.com/deltachat/message-parser/issues/12)"),
+        vec![
+            Text("for more information see ("),
+            Link {
+                destination: link_destination_for_testing("https://github.com/deltachat/message-parser/issues/12")
+            },
+            Text(")")
+        ]
+    );
+}
+
+
+#[test]
+fn link_with_parenthesis_in_parenthesis() {
+    assert_eq!(
+        parse_only_text("there are links that contain parenthesis (for example https://en.wikipedia.org/wiki/Bracket_(disambiguation))"),
+        vec![
+            Text("there are links that contain parenthesis (for example "),
+            Link {
+                destination: link_destination_for_testing("https://en.wikipedia.org/wiki/Bracket_(disambiguation)")
+            },
+            Text(")")
+        ]
+    );
+}
+
+#[test]
+fn link_with_different_parenthesis_in_parenthesis() {
+    assert_eq!(
+        parse_only_text("()(for [example{ https://en.wikipedia.org/wiki/Bracket_(disambiguation){[}hi]])}"),
+        vec![
+            Text("()(for [example{ "),
+            Link {
+                destination: link_destination_for_testing("https://en.wikipedia.org/wiki/Bracket_(disambiguation){[}hi]")
+            },
+            Text("])}")
+        ]
+    );
+}

--- a/tests/text_to_ast/text_only.rs
+++ b/tests/text_to_ast/text_only.rs
@@ -365,8 +365,6 @@ fn link_with_file_extention() {
     );
 }
 
-
-
 #[test]
 fn parenthesis_in_links() {
     assert_eq!(
@@ -384,17 +382,20 @@ fn parenthesis_in_links() {
 #[test]
 fn link_in_parenthesis() {
     assert_eq!(
-        parse_only_text("for more information see (https://github.com/deltachat/message-parser/issues/12)"),
+        parse_only_text(
+            "for more information see (https://github.com/deltachat/message-parser/issues/12)"
+        ),
         vec![
             Text("for more information see ("),
             Link {
-                destination: link_destination_for_testing("https://github.com/deltachat/message-parser/issues/12")
+                destination: link_destination_for_testing(
+                    "https://github.com/deltachat/message-parser/issues/12"
+                )
             },
             Text(")")
         ]
     );
 }
-
 
 #[test]
 fn link_with_parenthesis_in_parenthesis() {
@@ -413,13 +414,45 @@ fn link_with_parenthesis_in_parenthesis() {
 #[test]
 fn link_with_different_parenthesis_in_parenthesis() {
     assert_eq!(
-        parse_only_text("()(for [example{ https://en.wikipedia.org/wiki/Bracket_(disambiguation){[}hi]])}"),
+        parse_only_text(
+            "()(for [example{ https://en.wikipedia.org/wiki/Bracket_(disambiguation){[}hi]])}"
+        ),
         vec![
             Text("()(for [example{ "),
             Link {
-                destination: link_destination_for_testing("https://en.wikipedia.org/wiki/Bracket_(disambiguation){[}hi]")
+                destination: link_destination_for_testing(
+                    "https://en.wikipedia.org/wiki/Bracket_(disambiguation){[}hi]"
+                )
             },
             Text("])}")
+        ]
+    );
+}
+
+#[test]
+fn link_with_backets_in_backets() {
+    assert_eq!(
+        parse_only_text("there are links that contain backets [for example https://en.wikipedia.org/wiki/Bracket_[disambiguation]]"),
+        vec![
+            Text("there are links that contain backets [for example "),
+            Link {
+                destination: link_destination_for_testing("https://en.wikipedia.org/wiki/Bracket_[disambiguation]")
+            },
+            Text("]")
+        ]
+    );
+}
+
+#[test]
+fn link_with_parenthesis_in_parenthesis_curly() {
+    assert_eq!(
+        parse_only_text("there are links that contain parenthesis {for example https://en.wikipedia.org/wiki/Bracket_{disambiguation}}"),
+        vec![
+            Text("there are links that contain parenthesis {for example "),
+            Link {
+                destination: link_destination_for_testing("https://en.wikipedia.org/wiki/Bracket_{disambiguation}")
+            },
+            Text("}")
         ]
     );
 }

--- a/tests/text_to_ast/text_only.rs
+++ b/tests/text_to_ast/text_only.rs
@@ -456,3 +456,30 @@ fn link_with_parenthesis_in_parenthesis_curly() {
         ]
     );
 }
+
+#[test]
+fn link_with_descriptive_parenthesis() {
+    assert_eq!(
+        parse_only_text("https://delta.chat/page(this is the link to our site)"),
+        vec![
+            Link {
+                destination: link_destination_for_testing("https://delta.chat/page")
+            },
+            Text("(this is the link to our site)")
+        ]
+    );
+}
+
+#[test]
+fn link_in_parenthesis2() {
+    assert_eq!(
+        parse_only_text("A great chat app (see https://delta.chat/en/)"),
+        vec![
+            Text("A great chat app (see "),
+            Link {
+                destination: link_destination_for_testing("https://delta.chat/en/")
+            },
+            Text(")")
+        ]
+    );
+}


### PR DESCRIPTION
- add tests for #12
- allow other brackets in path part: `{`,`}`,`[`,`]`,`<`,`>`
- count the parentheses in links closes #12
- fix the second part of the issue #12 which I forgot to fix in the last commit: starting a bracket at the end of a link: `https://delta.chat/page(this is the link to our site)` (when it is not closed in the link its not taken)
