### PR TITLE
parse telephone numbers

### DIFF
--- a/message_parser_wasm/example.js
+++ b/message_parser_wasm/example.js
@@ -96,6 +96,12 @@ function renderElement(elm) {
         );
       return bcs;
 
+    case "TelephoneNumber":
+      let tn = document.createElement("a");
+      tn.innerText = elm.c.number;
+      tn.href = elm.c.tel_link;
+      return tn;
+
     case "Linebreak":
       return document.createElement("br");
 

--- a/message_parser_wasm/src/lib.rs
+++ b/message_parser_wasm/src/lib.rs
@@ -57,5 +57,6 @@ export type ParsedElement =
   | {
       t: "LabeledLink";
       c: { label: ParsedElement[]; destination: LinkDestination };
-    };
+    }
+  | {t: "TelephoneNumber", c: {number: string, tel_link: string}};
 "#;

--- a/message_parser_wasm/src/manual_typings.ts
+++ b/message_parser_wasm/src/manual_typings.ts
@@ -25,4 +25,5 @@ export type ParsedElement =
   | {
       t: "LabeledLink";
       c: { label: ParsedElement[]; destination: LinkDestination };
-    };
+    }
+  | {t: "TelephoneNumber", c: {number: string, tel_link: string}};

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -21,6 +21,12 @@ pub enum Element<'a> {
     Link {
         destination: LinkDestination<'a>,
     },
+    TelephoneNumber{
+        /// number exactly how it was found in the input text
+        number: &'a str,
+        /// the tel: link (without special chars, but keeps the + in the beginning if it is present)
+        tel_link: String,
+    },
     EmailAddress(&'a str),
     // Later:
     // Mention {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -21,7 +21,7 @@ pub enum Element<'a> {
     Link {
         destination: LinkDestination<'a>,
     },
-    TelephoneNumber{
+    TelephoneNumber {
         /// number exactly how it was found in the input text
         number: &'a str,
         /// the tel: link (without special chars, but keeps the + in the beginning if it is present)

--- a/src/parser/parse_from_text/base_parsers.rs
+++ b/src/parser/parse_from_text/base_parsers.rs
@@ -19,6 +19,7 @@ pub enum CustomError<I> {
     UnexpectedContent,
     PrecedingWhitespaceMissing,
     OptionIsUnexpectedNone,
+    PhoneNumberNotEnoughDigits,
     UnxepectedError(String),
 }
 

--- a/src/parser/parse_from_text/mod.rs
+++ b/src/parser/parse_from_text/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod base_parsers;
 mod desktop_subset;
 pub mod hashtag_content_char_ranges;
 mod markdown_elements;
+mod phone_numbers;
 mod text_elements;
 
 /// parses text elements such as links and email addresses, excluding markdown

--- a/src/parser/parse_from_text/phone_numbers.rs
+++ b/src/parser/parse_from_text/phone_numbers.rs
@@ -20,7 +20,7 @@ fn is_sdd(input: char) -> bool {
 }
 
 fn is_digit(input: char) -> bool {
-    input.is_digit(10)
+    input.is_ascii_digit()
 }
 
 fn is_digit_or_ssd(input: char) -> bool {

--- a/src/parser/parse_from_text/phone_numbers.rs
+++ b/src/parser/parse_from_text/phone_numbers.rs
@@ -139,7 +139,7 @@ mod test {
     }
 
     #[test]
-    fn test_not_enough_digits(){
+    fn test_not_enough_digits() {
         telephone_number("(0)152 28").expect_err("fails because number is to short");
         telephone_number("152 28").expect_err("fails because too short");
         telephone_number("(152) 28").expect_err("fails because too short");

--- a/src/parser/parse_from_text/text_elements.rs
+++ b/src/parser/parse_from_text/text_elements.rs
@@ -3,6 +3,7 @@ use crate::parser::link_url::LinkDestination;
 
 use super::base_parsers::*;
 use super::hashtag_content_char_ranges::hashtag_content_char;
+use super::phone_numbers::telephone_number;
 use super::Element;
 use crate::nom::{Offset, Slice};
 use nom::bytes::complete::take_while;
@@ -274,6 +275,8 @@ pub(crate) fn parse_text_element(
             Err(nom::Err::Error(CustomError::PrecedingWhitespaceMissing))
         }
     } {
+        Ok((i, elm))
+    } else if let Ok((i, elm)) = telephone_number(input) {
         Ok((i, elm))
     } else if let Ok((i, _)) = linebreak(input) {
         Ok((i, Element::Linebreak))


### PR DESCRIPTION
- [x] basic parsing
- [ ] more testing
- [ ] document format in spec.md
- [x] integrate element into text parsing
- [ ] add test for phone numbers in text
- [ ] add test for phone numbers in desktop set & markdown

closes #3 


we can take googles library for reference: https://github.com/google/libphonenumber, it is used by telegram iOS, signal desktop and probably also android os