### PR TITLE
fix #67: Mistaking UN*X absolute paths as bot commands

### DIFF
--- a/src/parser/parse_from_text/text_elements.rs
+++ b/src/parser/parse_from_text/text_elements.rs
@@ -230,7 +230,7 @@ pub(crate) fn link(input: &str) -> IResult<&str, Element, CustomError<&str>> {
 */
 fn is_allowed_bot_cmd_suggestion_char(char: char) -> bool {
     match char {
-        '@' | '\\' | '_' | '/' | '.' | '-' => true,
+        '@' | '\\' | '_' | '.' | '-' | '/' => true,
         _ => char.is_alphanum(),
     }
 }
@@ -248,8 +248,11 @@ fn bot_command_suggestion(input: &str) -> IResult<&str, Element, CustomError<&st
             s.len() < 256
         }),
     )))(input)?;
-
-    Ok((input, Element::BotCommandSuggestion(content)))
+    if content[1..].contains('/') {
+        Ok((input, Element::Text(content)))
+    } else {
+        Ok((input, Element::BotCommandSuggestion(content)))
+    }
 }
 
 pub(crate) fn parse_text_element(
@@ -269,7 +272,9 @@ pub(crate) fn parse_text_element(
         if prev_char == Some(' ') || prev_char.is_none() {
             bot_command_suggestion(input)
         } else {
-            Err(nom::Err::Error(CustomError::PrecedingWhitespaceMissing))
+            Err(nom::Err::Error(
+                CustomError::<&str>::PrecedingWhitespaceMissing,
+            ))
         }
     } {
         Ok((i, elm))

--- a/src/parser/parse_from_text/text_elements.rs
+++ b/src/parser/parse_from_text/text_elements.rs
@@ -5,13 +5,13 @@ use super::hashtag_content_char_ranges::hashtag_content_char;
 use super::Element;
 use nom::{
     bytes::{
-        complete::{tag, take, take_while1, take_while},
+        complete::{tag, take, take_while, take_while1},
         streaming::take_till1,
     },
     character::complete::char,
     combinator::{peek, recognize, verify},
     sequence::tuple,
-    AsChar, IResult, Slice, Offset
+    AsChar, IResult, Offset, Slice,
 };
 
 use super::base_parsers::CustomError;
@@ -21,10 +21,7 @@ fn linebreak(input: &str) -> IResult<&str, char, CustomError<&str>> {
 }
 
 fn hashtag(input: &str) -> IResult<&str, Element, CustomError<&str>> {
-    let (input, content) = recognize(tuple((
-        char('#'),
-        take_while1(hashtag_content_char),
-    )))(input)?;
+    let (input, content) = recognize(tuple((char('#'), take_while1(hashtag_content_char))))(input)?;
 
     Ok((input, Element::Tag(content)))
 }

--- a/src/parser/parse_from_text/text_elements.rs
+++ b/src/parser/parse_from_text/text_elements.rs
@@ -1,19 +1,20 @@
+///! nom parsers for text elements
+use crate::parser::link_url::LinkDestination;
+
+use super::hashtag_content_char_ranges::hashtag_content_char;
+use super::Element;
 use nom::{
     bytes::{
-        complete::{tag, take, take_while, take_while1},
+        complete::{tag, take, take_while1, take_while},
         streaming::take_till1,
     },
-    character,
     character::complete::char,
     combinator::{peek, recognize, verify},
     sequence::tuple,
-    AsChar, IResult, Offset, Slice,
+    AsChar, IResult, Slice, Offset
 };
 
 use super::base_parsers::CustomError;
-use super::hashtag_content_char_ranges::hashtag_content_char;
-use super::Element;
-use crate::parser::link_url::LinkDestination;
 
 fn linebreak(input: &str) -> IResult<&str, char, CustomError<&str>> {
     char('\n')(input)
@@ -21,7 +22,7 @@ fn linebreak(input: &str) -> IResult<&str, char, CustomError<&str>> {
 
 fn hashtag(input: &str) -> IResult<&str, Element, CustomError<&str>> {
     let (input, content) = recognize(tuple((
-        character::complete::char('#'),
+        char('#'),
         take_while1(hashtag_content_char),
     )))(input)?;
 
@@ -248,7 +249,7 @@ fn bot_command_suggestion(input: &str) -> IResult<&str, Element, CustomError<&st
             s.len() < 256
         }),
     )))(input)?;
-    if content[1..].contains('/') {
+    if content.slice(1..).contains('/') {
         Ok((input, Element::Text(content)))
     } else {
         Ok((input, Element::BotCommandSuggestion(content)))

--- a/tests/text_to_ast/text_only.rs
+++ b/tests/text_to_ast/text_only.rs
@@ -54,6 +54,12 @@ fn command_suggestions() {
 }
 
 #[test]
+fn unix_abs_path_is_not_command() {
+    let input = "/etc/nginx";
+    assert_eq!(parse_only_text(input), vec![Text("/etc/nginx")]);
+}
+
+#[test]
 fn invalid_command_suggestions() {
     let input = "/1\n /hello world";
     assert_eq!(


### PR DESCRIPTION
The solution is simple:

If there is a `/` in the parsed command other than in the start, it's a Text Element rather than a BotCommandSuggestion Element.