### PR TITLE
Add (failing) tests

### DIFF
--- a/tests/text_to_ast/desktop_set.rs
+++ b/tests/text_to_ast/desktop_set.rs
@@ -422,6 +422,20 @@ fn labeled_link() {
 }
 
 #[test]
+fn labeled_link_domain_only() {
+    assert_eq!(
+        parse_desktop_set("[a link](https://delta.chat)"),
+        vec![LabeledLink {
+            label: vec![Text("a link")],
+            destination: https_link_no_puny(
+                "https://delta.chat",
+                "delta.chat"
+            ),
+        }]
+    );
+}
+
+#[test]
 fn labeled_link_no_markdown_in_desktop_set() {
     assert_ne!(
         parse_desktop_set(

--- a/tests/text_to_ast/markdown.rs
+++ b/tests/text_to_ast/markdown.rs
@@ -716,6 +716,36 @@ fn labeled_link_example() {
 }
 
 #[test]
+fn labeled_link_example_domain_only() {
+    assert_eq!(
+        parse_markdown_text("you can find the details [here](https://delta.chat)."),
+        vec![
+            Text("you can find the details "),
+            LabeledLink {
+                label: vec![Text("here")],
+                destination: https_link_no_puny("https://delta.chat", "delta.chat"),
+            },
+            Text(".")
+        ]
+    );
+}
+
+#[test]
+fn labeled_link_works_without_trailing_space() {
+    assert_eq!(
+        parse_markdown_text("you can find the details [here](https://delta.chat)foo(bar)."),
+        vec![
+            Text("you can find the details "),
+            LabeledLink {
+                label: vec![Text("here")],
+                destination: https_link_no_puny("https://delta.chat", "delta.chat"),
+            },
+            Text("foo(bar).")
+        ]
+    );
+}
+
+#[test]
 fn labeled_link_can_have_comma_or_dot_at_end() {
     assert_eq!(
         parse_markdown_text("you can find the details [here](https://delta.chat/en/help.)."),


### PR DESCRIPTION
related to #88 #89 #91

This PR just adds some (failing) tests to address the known bugs around labeled links.

Since there are more parsing bugs like these, maybe it makes sense to make use of existing libraries before inventing the wheel a second time?

https://docs.rs/url/latest/url/ for link parsing

https://github.com/wooorm/markdown-rs for parsing markup