### PR TITLE
Match links with multiple hash (#) characters correctly

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -42,8 +42,12 @@ Make URLs clickable.
 
 - detect all valid hyperlink URLs that have the `://` (protocol://host).
   - according to [RFC3987](https://www.rfc-editor.org/rfc/rfc3987) and [RFC3988](https://www.rfc-editor.org/rfc/rfc3988)
+  - In addition to the spec, explicitly allow multiple `#` characters in the ifragment, leaving it up to the destination to handle correctly.
 
 - other links like `mailto:` (note there is just a single `:`, no `://`) will get separate parsing that includes a whitelisted protocol name, otherwise there will likely be unexpected behavior if user types `hello:world` - will be recognized as link.
+
+- allow simple links without protocol scheme so long as they match the original world wide TLDs or `chat`.
+  - see [RFC1591](https://www.rfc-editor.org/rfc/rfc1591) for world wide domains
 
 - `.`,`,`,`;`,`:` should not be parsed as an ending char of an inline-link(this rule is only for standalone/inline links)
 

--- a/src/parser/link_url/parse_link.rs
+++ b/src/parser/link_url/parse_link.rs
@@ -251,7 +251,7 @@ fn take_while_pct_encoded(input: &str) -> IResult<&str, &str, CustomError<&str>>
 }
 
 fn ifragment(input: &str) -> IResult<&str, &str, CustomError<&str>> {
-    recognize(tuple((char('#'), take_while_ifragment)))(input)
+    recognize(many0(tuple((char('#'), take_while_ifragment))))(input)
 }
 
 fn parse_ipath_abempty(input: &str) -> IResult<&str, &str, CustomError<&str>> {

--- a/tests/links.rs
+++ b/tests/links.rs
@@ -25,6 +25,7 @@ fn basic_parsing() {
         "ftp://test-test",
         "https://www.openmandriva.org/en/news/article/openmandriva-rome-24-07-released",
         "https://www.openmandriva.org///en/news/article/openmandriva-rome-24-07-released",
+        "https://matrix.to/#/#deltachat:matrix.org"
     ];
 
     let test_cases_with_puny = vec!["https://ü.app#help", "http://münchen.de"];

--- a/tests/links.rs
+++ b/tests/links.rs
@@ -25,7 +25,6 @@ fn basic_parsing() {
         "ftp://test-test",
         "https://www.openmandriva.org/en/news/article/openmandriva-rome-24-07-released",
         "https://www.openmandriva.org///en/news/article/openmandriva-rome-24-07-released",
-        "https://matrix.to/#/#deltachat:matrix.org"
     ];
 
     let test_cases_with_puny = vec!["https://ü.app#help", "http://münchen.de"];
@@ -48,6 +47,21 @@ fn basic_parsing() {
         assert_eq!(rest.len(), 0);
         assert_eq!(input, &link_destination.target);
     }
+}
+
+#[test]
+fn multiple_hashes() {
+    assert_eq!(
+        LinkDestination::parse("https://matrix.to/#/#deltachat:matrix.org")
+            .unwrap()
+            .1,
+        LinkDestination {
+            hostname: Some("matrix.to"),
+            target: "https://matrix.to/#/#deltachat:matrix.org",
+            scheme: "https",
+            punycode: None,
+        }
+    );
 }
 
 #[test]

--- a/tests/links.rs
+++ b/tests/links.rs
@@ -58,7 +58,7 @@ fn multiple_hashes() {
         LinkDestination {
             hostname: Some("matrix.to"),
             target: "https://matrix.to/#/#deltachat:matrix.org",
-            scheme: "https",
+            scheme: Some("https"),
             punycode: None,
         }
     );


### PR DESCRIPTION
Should fix #101 Added test case from issue, this makes the parser more greedy in matching everything after first hash character as being part of the ifragment (see https://www.rfc-editor.org/rfc/rfc3987 page 7).

This is my first contribution in rust and for deltachat, happy to receive feedback and criticism to help me improve 😄 
