### PR TITLE
Parse simple links

### DIFF
--- a/message_parser_wasm/src/manual_typings.ts
+++ b/message_parser_wasm/src/manual_typings.ts
@@ -9,6 +9,7 @@ export type LinkDestination = {
   target: string;
   hostname: null | string;
   punycode: null | PunycodeWarning;
+  scheme: null | string;
 };
 export type ParsedElement =
   | { t: "Text"; c: string }

--- a/src/parser/link_url/mod.rs
+++ b/src/parser/link_url/mod.rs
@@ -33,7 +33,7 @@ pub struct LinkDestination<'a> {
     /// (the host part contains non ascii unicode characters)
     pub punycode: Option<PunycodeWarning>,
     /// scheme
-    pub scheme: &'a str,
+    pub scheme: Option<&'a str>,
 }
 
 impl LinkDestination<'_> {

--- a/src/parser/link_url/parse_link.rs
+++ b/src/parser/link_url/parse_link.rs
@@ -354,10 +354,10 @@ fn parse_iri(input: &str) -> IResult<&str, LinkDestination, CustomError<&str>> {
                 } else {
                     get_puny_code_warning(link, host)
                 },
-                scheme: if !scheme.is_empty() {
-                    Some(scheme)
-                } else {
+                scheme: if scheme.is_empty() {
                     None
+                } else {
+                    Some(scheme)
                 },
             },
         ));

--- a/src/parser/link_url/parse_link.rs
+++ b/src/parser/link_url/parse_link.rs
@@ -357,7 +357,7 @@ fn parse_iri(input: &str) -> IResult<&str, LinkDestination, CustomError<&str>> {
                 } else {
                     get_puny_code_warning(link, host)
                 },
-                scheme: if scheme.len() > 0 { Some(scheme) } else { None },
+                scheme: if !scheme.is_empty() { Some(scheme) } else { None },
             },
         ));
     }

--- a/src/parser/link_url/parse_link.rs
+++ b/src/parser/link_url/parse_link.rs
@@ -300,7 +300,7 @@ fn parse_iri(input: &str) -> IResult<&str, LinkDestination, CustomError<&str>> {
         ALLOWED_TOP_LEVEL_DOMAINS
             .iter()
             .find(|&&tld| host.ends_with(tld))
-            .ok_or_else(|| nom::Err::Failure(CustomError::<&str>::InvalidLink))?;
+            .ok_or(nom::Err::Failure(CustomError::<&str>::InvalidLink))?;
     }
 
     let (input, path) = opt(alt((
@@ -357,7 +357,7 @@ fn parse_iri(input: &str) -> IResult<&str, LinkDestination, CustomError<&str>> {
                 } else {
                     get_puny_code_warning(link, host)
                 },
-                scheme,
+                scheme: if scheme.len() > 0 { Some(scheme) } else { None },
             },
         ));
     }
@@ -379,7 +379,7 @@ fn parse_generic(input: &str) -> IResult<&str, LinkDestination, CustomError<&str
         return Ok((
             input,
             LinkDestination {
-                scheme,
+                scheme: Some(scheme),
                 target,
                 hostname: None,
                 punycode: None,

--- a/src/parser/link_url/parse_link.rs
+++ b/src/parser/link_url/parse_link.rs
@@ -232,17 +232,14 @@ fn scheme_and_separator(input: &str) -> IResult<&str, (&str, &str), CustomError<
 
 #[test]
 fn scheme_with_separator() {
-    let (rest, result) = opt(scheme_and_separator)("scheme:host/path").unwrap();
-    assert_eq!(Some(("scheme", ":")), result);
-    assert_eq!("host/path", rest);
+    let result = opt(scheme_and_separator)("scheme:host/path");
+    assert_eq!(Ok(("host/path", Some(("scheme", ":")))), result);
 
-    let (rest, result) = opt(scheme_and_separator)("scheme://host/path").unwrap();
-    assert_eq!(Some(("scheme", "://")), result);
-    assert_eq!("host/path", rest);
+    let result = opt(scheme_and_separator)("scheme://host/path");
+    assert_eq!(Ok(("host/path", Some(("scheme", "://")))), result);
 
-    let (rest, result) = opt(scheme_and_separator)("no_scheme/host/path").unwrap();
-    assert_eq!(None, result);
-    assert_eq!("no_scheme/host/path", rest);
+    let result = opt(scheme_and_separator)("no_scheme/host/path");
+    assert_eq!(Ok(("no_scheme/host/path", None)), result);
 }
 
 /// Take as many pct encoded blocks as there are. a block is %XX where X is a hex digit
@@ -357,7 +354,11 @@ fn parse_iri(input: &str) -> IResult<&str, LinkDestination, CustomError<&str>> {
                 } else {
                     get_puny_code_warning(link, host)
                 },
-                scheme: if !scheme.is_empty() { Some(scheme) } else { None },
+                scheme: if !scheme.is_empty() {
+                    Some(scheme)
+                } else {
+                    None
+                },
             },
         ));
     }

--- a/src/parser/link_url/parse_link.rs
+++ b/src/parser/link_url/parse_link.rs
@@ -284,7 +284,7 @@ fn test_ipath_absolute() {
 fn parse_iri(input: &str) -> IResult<&str, LinkDestination, CustomError<&str>> {
     let input_ = <&str>::clone(&input);
 
-    // a link is [scheme] ['://'] <iauthority> [ipath] [iquery] [ifragment]
+    // A link is [scheme] ['://'] <iauthority> [ipath] [iquery] [ifragment]
     let (input, scheme_parts) = opt(scheme_and_separator)(input)?;
     let (scheme, separator) = scheme_parts.unwrap_or(("", ""));
 
@@ -317,8 +317,8 @@ fn parse_iri(input: &str) -> IResult<&str, LinkDestination, CustomError<&str>> {
 
     let (_, fragment) = opt(ifragment)(input)?;
     let fragment = fragment.unwrap_or("");
-    let ihier_len = 0usize
-        .saturating_add(authority.len())
+    let ihier_len = authority
+        .len()
         .saturating_add(host.len())
         .saturating_add(path.len());
     if ihier_len == 0 {

--- a/src/parser/link_url/parse_link.rs
+++ b/src/parser/link_url/parse_link.rs
@@ -46,7 +46,7 @@ fn is_allowed_generic_scheme(scheme: &str) -> bool {
     )
 }
 
-const ALLOWED_TOP_LEVEL_DOMAINS: &'static [&'static str] = &[
+const ALLOWED_TOP_LEVEL_DOMAINS: &[&str] = &[
     // originals from RFC920 + net
     ".com",
     ".org",

--- a/tests/links.rs
+++ b/tests/links.rs
@@ -91,7 +91,7 @@ fn punycode_detection() {
         LinkDestination {
             hostname: Some("muenchen.de"),
             target: "http://muenchen.de",
-            scheme:  Some("http"),
+            scheme: Some("http"),
             punycode: None,
         }
     );
@@ -106,7 +106,7 @@ fn common_schemes() {
             LinkDestination {
                 hostname: Some("delta.chat"),
                 target: "http://delta.chat",
-                scheme:  Some("http"),
+                scheme: Some("http"),
                 punycode: None,
             }
         )
@@ -118,7 +118,7 @@ fn common_schemes() {
             LinkDestination {
                 hostname: Some("far.chickenkiller.com"),
                 target: "https://far.chickenkiller.com",
-                scheme:  Some("https"),
+                scheme: Some("https"),
                 punycode: None,
             }
         )
@@ -132,7 +132,7 @@ fn generic_schemes() {
             "",
             LinkDestination {
                 hostname: None,
-                scheme:  Some("mailto"),
+                scheme: Some("mailto"),
                 punycode: None,
                 target: "mailto:someone@example.com"
             }
@@ -144,7 +144,7 @@ fn generic_schemes() {
             .1,
         LinkDestination {
             hostname: None,
-            scheme:  Some("bitcoin"),
+            scheme: Some("bitcoin"),
             target: "bitcoin:bc1qt3xhfvwmdqvxkk089tllvvtzqs8ts06u3u6qka",
             punycode: None,
         }
@@ -154,7 +154,7 @@ fn generic_schemes() {
             .unwrap()
             .1,
         LinkDestination {
-            scheme:  Some("geo"),
+            scheme: Some("geo"),
             punycode: None,
             target: "geo:37.786971,-122.399677",
             hostname: None

--- a/tests/links.rs
+++ b/tests/links.rs
@@ -77,7 +77,7 @@ fn punycode_detection() {
         LinkDestination {
             hostname: Some("münchen.de"),
             target: "http://münchen.de",
-            scheme: "http",
+            scheme: Some("http"),
             punycode: Some(PunycodeWarning {
                 original_hostname: "münchen.de".to_owned(),
                 ascii_hostname: "xn--mnchen-3ya.de".to_owned(),
@@ -91,7 +91,7 @@ fn punycode_detection() {
         LinkDestination {
             hostname: Some("muenchen.de"),
             target: "http://muenchen.de",
-            scheme: "http",
+            scheme:  Some("http"),
             punycode: None,
         }
     );
@@ -106,7 +106,7 @@ fn common_schemes() {
             LinkDestination {
                 hostname: Some("delta.chat"),
                 target: "http://delta.chat",
-                scheme: "http",
+                scheme:  Some("http"),
                 punycode: None,
             }
         )
@@ -118,7 +118,7 @@ fn common_schemes() {
             LinkDestination {
                 hostname: Some("far.chickenkiller.com"),
                 target: "https://far.chickenkiller.com",
-                scheme: "https",
+                scheme:  Some("https"),
                 punycode: None,
             }
         )
@@ -132,7 +132,7 @@ fn generic_schemes() {
             "",
             LinkDestination {
                 hostname: None,
-                scheme: "mailto",
+                scheme:  Some("mailto"),
                 punycode: None,
                 target: "mailto:someone@example.com"
             }
@@ -144,7 +144,7 @@ fn generic_schemes() {
             .1,
         LinkDestination {
             hostname: None,
-            scheme: "bitcoin",
+            scheme:  Some("bitcoin"),
             target: "bitcoin:bc1qt3xhfvwmdqvxkk089tllvvtzqs8ts06u3u6qka",
             punycode: None,
         }
@@ -154,7 +154,7 @@ fn generic_schemes() {
             .unwrap()
             .1,
         LinkDestination {
-            scheme: "geo",
+            scheme:  Some("geo"),
             punycode: None,
             target: "geo:37.786971,-122.399677",
             hostname: None
@@ -163,20 +163,23 @@ fn generic_schemes() {
 }
 
 #[test]
-fn no_scheme() {
+fn no_scheme_simple() {
     assert_eq!(
         LinkDestination::parse("example.com").unwrap(),
         (
             "",
             LinkDestination {
                 hostname: Some("example.com"),
-                scheme: "",
+                scheme: None,
                 punycode: None,
                 target: "example.com"
             }
         )
     );
+}
 
+#[test]
+fn no_scheme_with_chat() {
     // exceptional
     assert_eq!(
         LinkDestination::parse("delta.chat").unwrap(),
@@ -184,13 +187,16 @@ fn no_scheme() {
             "",
             LinkDestination {
                 hostname: Some("delta.chat"),
-                scheme: "",
+                scheme: None,
                 punycode: None,
                 target: "delta.chat"
             }
         )
     );
+}
 
+#[test]
+fn no_scheme_full_iri_segments() {
     // long one with all the path segments
     assert_eq!(
         LinkDestination::parse("delta.chat/path/with/segments?query=params#fragment").unwrap(),
@@ -198,13 +204,16 @@ fn no_scheme() {
             "",
             LinkDestination {
                 hostname: Some("delta.chat"),
-                scheme: "",
+                scheme: None,
                 punycode: None,
                 target: "delta.chat/path/with/segments?query=params#fragment"
             }
         )
     );
+}
 
+#[test]
+fn no_scheme_punycode() {
     // punycode
     assert_eq!(
         LinkDestination::parse("münchen.com").unwrap(),
@@ -212,7 +221,7 @@ fn no_scheme() {
             "",
             LinkDestination {
                 hostname: Some("münchen.com"),
-                scheme: "",
+                scheme: None,
                 punycode: Some(PunycodeWarning {
                     original_hostname: "münchen.com".to_owned(),
                     ascii_hostname: "xn--mnchen-3ya.com".to_owned(),
@@ -222,15 +231,24 @@ fn no_scheme() {
             }
         )
     );
+}
 
+#[test]
+fn no_scheme_disallow_zip() {
     // Failing case for unsupported TLD
     let result = LinkDestination::parse("free_money.zip");
     assert!(result.is_err());
+}
 
+#[test]
+fn no_scheme_disallow_authority() {
     // Failing case with user prefix, we dont want this for simple links without scheme
     let result = LinkDestination::parse("user@delta.chat");
     assert!(result.is_err());
+}
 
+#[test]
+fn no_scheme_disallow_port() {
     // Failing case with port, also not good for simple links without scheme
     let result = LinkDestination::parse("delta.chat:8080/api");
     assert!(result.is_ok());

--- a/tests/links.rs
+++ b/tests/links.rs
@@ -25,6 +25,8 @@ fn basic_parsing() {
         "ftp://test-test",
         "https://www.openmandriva.org/en/news/article/openmandriva-rome-24-07-released",
         "https://www.openmandriva.org///en/news/article/openmandriva-rome-24-07-released",
+        "www.delta.chat",
+        "example.com/some/link?q=something#hash-fragment",
     ];
 
     let test_cases_with_puny = vec!["https://ü.app#help", "http://münchen.de"];

--- a/tests/links.rs
+++ b/tests/links.rs
@@ -163,3 +163,13 @@ fn generic_schemes() {
         }
     );
 }
+
+
+#[test]
+fn isolated_link() {
+    // assert_eq!((LinkDestination::parse("http://whatever1.com/path").unwrap().1).target, "http://whatever1.com/path");
+    // assert_eq!((LinkDestination::parse("whatever2.com/path").unwrap().1).target, "whatever2.com/path");
+    assert_eq!((LinkDestination::parse("whatever3.com").unwrap().1).target, "whatever3.com");
+}
+
+

--- a/tests/text_to_ast/desktop_set.rs
+++ b/tests/text_to_ast/desktop_set.rs
@@ -463,7 +463,7 @@ fn labeled_link_with_special_char_in_domain() {
                     ascii_hostname: "xn--mnchen-3ya.de".to_string(),
                     punycode_encoded_url: "https://xn--mnchen-3ya.de".to_string()
                 }),
-                scheme: "https"
+                scheme: Some("https")
             },
         }]
     );

--- a/tests/text_to_ast/mod.rs
+++ b/tests/text_to_ast/mod.rs
@@ -5,7 +5,7 @@ pub(crate) fn gopher_link_no_puny<'a>(target: &'a str, hostname: &'a str) -> Lin
     LinkDestination {
         target,
         hostname: Some(hostname),
-        scheme: "gopher",
+        scheme: Some("gopher"),
         punycode: None,
     }
 }
@@ -14,7 +14,7 @@ pub(crate) fn http_link_no_puny<'a>(target: &'a str, hostname: &'a str) -> LinkD
     LinkDestination {
         target,
         hostname: Some(hostname),
-        scheme: "http",
+        scheme: Some("http"),
         punycode: None,
     }
 }
@@ -23,7 +23,7 @@ pub(crate) fn ftp_link_no_puny<'a>(target: &'a str, hostname: &'a str) -> LinkDe
     LinkDestination {
         target,
         hostname: Some(hostname),
-        scheme: "ftp",
+        scheme: Some("ftp"),
         punycode: None,
     }
 }
@@ -32,7 +32,7 @@ pub(crate) fn https_link_no_puny<'a>(target: &'a str, hostname: &'a str) -> Link
     LinkDestination {
         target,
         hostname: Some(hostname),
-        scheme: "https",
+        scheme: Some("https"),
         punycode: None,
     }
 }
@@ -41,7 +41,7 @@ pub(crate) fn mailto_link_no_puny(target: &str) -> LinkDestination<'_> {
     LinkDestination {
         target,
         hostname: None,
-        scheme: "mailto",
+        scheme: Some("mailto"),
         punycode: None,
     }
 }


### PR DESCRIPTION
Hi, here's a working WIP of parsing the simple links from #33
I created two test cases in `tests/links.rs` that now pass 😃 ✔️ 

Currently it checks only classic TLDs (.com, .net etc) and .chat but it will be easy to add the country code TLDs to the vector later.

I have two questions where I'm unsure about the quality:

1. given that most of the code here is done with nom parsing does it make sense to use `host.ends_with(allowed_domain)` in a for loop against the allow list of TLDs? I didn't see a way to do this using something built in to the crate
2. I wasn't sure about returning an empty scheme with the correct lifetime ('a matching the link) so I did `link.slice(0..0)` which feels quite wrong. Any tips on how to handle this better?