### PR TITLE
Disallow double quotes in email address, remove repeated trailing '.' from email address

### DIFF
--- a/src/parser/parse_from_text/text_elements.rs
+++ b/src/parser/parse_from_text/text_elements.rs
@@ -44,6 +44,7 @@ fn not_email_address_part_char(c: char) -> bool {
             | '}'
             | '['
             | ']'
+            | '"'
     )
 }
 
@@ -67,17 +68,15 @@ pub(crate) fn email_address(input: &str) -> IResult<&str, Element, CustomError<&
     let i2 = <&str>::clone(&input);
     let i3 = <&str>::clone(&input);
     let (input, content) = match email_intern(i) {
-        Ok((remaining, _)) => {
+        Ok((mut remaining, _)) => {
             let index = i2.offset(remaining);
-            let consumed = i2.slice(..index);
-            if let Some('.') = consumed.chars().last() {
+            let mut consumed = i2.slice(..index);
+            while let Some('.') = consumed.chars().last() {
                 let index = input.offset(remaining).saturating_sub(1);
-                let consumed = i3.slice(..index);
-                let remaining = input.slice(index..);
-                Ok((remaining, consumed))
-            } else {
-                Ok((remaining, consumed))
+                consumed = i3.slice(..index);
+                remaining = input.slice(index..);
             }
+            Ok((remaining, consumed))
         }
         Err(e) => Err(e),
     }?;

--- a/tests/text_to_ast/text_only.rs
+++ b/tests/text_to_ast/text_only.rs
@@ -207,6 +207,32 @@ fn email_address_standalone() {
         vec![EmailAddress("mr.cow@moo.com"), Text("}")]
     );
 }
+#[test]
+fn email_address_excludes_quotes() {
+    // disallow " around email
+    assert_eq!(
+        parse_only_text("\"mr.cow@moo.com\""),
+        vec![Text("\""), EmailAddress("mr.cow@moo.com"), Text("\"")]
+    );
+}
+
+#[test]
+fn email_address_excludes_trailing_dots() {
+    // grab all trailing dots so they dont get confused with domain name
+    assert_eq!(
+        parse_only_text("reach me at example@example.com... or not!"),
+        vec![
+            Text("reach me at "),
+            EmailAddress("example@example.com"),
+            Text("... or not!")
+        ]
+    );
+    // prove domains with many dots inside still work ok
+    assert_eq!(
+        parse_only_text("my email is user@sub.domain.co.uk"),
+        vec![Text("my email is "), EmailAddress("user@sub.domain.co.uk")]
+    );
+}
 
 #[test]
 fn email_address_example() {


### PR DESCRIPTION
Should close https://github.com/deltachat/message-parser/issues/78
- [x] Double quote characters are no longer matched as part of the email address but parsed into neighboring Text elements
- [x] remove repeated trailing '.' from email address. Before this message-parser only correctly split one trailing period